### PR TITLE
DEV-25 Added possible fix for scc issue

### DIFF
--- a/pycaption/scc/__init__.py
+++ b/pycaption/scc/__init__.py
@@ -523,7 +523,14 @@ class SCCWriter(BaseWriter):
 
         # PASS 3:
         # Write captions.
+        # *Note* previous_start_time keeps track of previous start value for
+        #        validating if next iteration Has a start value that is lesser
+        #        or equal to "previous_start_time".
+        previous_start_time = -1
         for (code, start, end) in codes:
+            while start <= previous_start_time:
+                start = previous_start_time + 1000.0 * 60
+            previous_start_time = start
             output += ('%s\t' % self._format_timestamp(start))
             output += '94ae 94ae 9420 9420 '
             output += code


### PR DESCRIPTION
https://cielo24.atlassian.net/browse/DEV-25

It appears SRT to SCC breaks if there are duplicate or previous time codes ( from the last time code in the iteration ) Suggestion for a fix is to keep track of previous timecodes and make sure we are increasing those frames if they are duplicated or are back in time

